### PR TITLE
Always send MIME header `X-Mailgun-Rewrite-Sender-Header=false`

### DIFF
--- a/Mail/Hailgun/SendEmail.hs
+++ b/Mail/Hailgun/SendEmail.hs
@@ -43,6 +43,13 @@ toSimpleEmailParts :: HailgunMessage -> [(BC.ByteString, BC.ByteString)]
 toSimpleEmailParts message =
    [ (BC.pack "from", messageFrom message)
    , (BC.pack "subject", T.encodeUtf8 $ messageSubject message)
+   -- we want to omit the `Sender` header to avoid shenanigans with some email
+   -- clients when the `Sender` header and the `From` field don't originate from
+   -- the same root domain. in some circumstances this caused the "reply"
+   -- feature to break by attempting to use the `Sender`, which is
+   -- undeliverable, instead of the `From` address. this magic header is
+   -- undocumented and may break at literally any time. godspeed.
+   , (BC.pack "h:X-Mailgun-Rewrite-Sender-Header", BC.pack "false")
    ] ++ to
    ++ cc
    ++ bcc


### PR DESCRIPTION
This is an internal, hidden, entirely magic MIME header (h/t @m5) that
instructs Mailgun to omit the `Sender` header, altering the behavior of
some of our customer's email clients when we send emails from a
subdomain of mercury but intend the reply address to be from the root
domain.