### PR TITLE
cabal command updates

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -15,6 +15,9 @@ steps:
     cabal install --only-dependencies --lib
     cabal build
 
+To test it in a REPL environment:
+    cabal repl
+
 At that point in time you should have a working version of the library. If you wish to see the
 library in action then you could look at the [hailgun-send library][3].
 

--- a/README.markdown
+++ b/README.markdown
@@ -12,7 +12,8 @@ The goal of this library is match this API 1-1.
 This library just uses [cabal][2] to build itself. To do so for development then follow the following
 steps:
 
-    cabal install --only-dependencies --lib
+    cabal install --only-dependencies --lib (This works with the cabal file as is)
+    cabal install --only-dependencies (This only works if you configured an executable in the cabal file)
     cabal build
 
 To test it in a REPL environment:

--- a/README.markdown
+++ b/README.markdown
@@ -12,8 +12,7 @@ The goal of this library is match this API 1-1.
 This library just uses [cabal][2] to build itself. To do so for development then follow the following
 steps:
 
-    cabal sandbox init
-    cabal install --only-dependencies
+    cabal install --only-dependencies --lib
     cabal build
 
 At that point in time you should have a working version of the library. If you wish to see the


### PR DESCRIPTION
`cabal sandbox init` has been [deprecated](https://stackoverflow.com/questions/63491365/cabal-version-3-2-unrecognised-command-sandbox-try-help)
`cabal install --only-dependencies` does not work [unless you add a `--lib` header to it](https://github.com/haskell/cabal/issues/6246) (This is due to the cabal file not containing any executables in it)

`cabal repl` seems to be a useful command for testing code in a REPL environment